### PR TITLE
Fix For NVDA speech not working correctly with apostrophes.

### DIFF
--- a/SRC/NVDA.cpp
+++ b/SRC/NVDA.cpp
@@ -32,6 +32,8 @@ bool NVDA::Speak(const char* text, bool interrupt) {
 	if (!GetActive())return false;
 	if (interrupt)
 		nvdaController_cancelSpeech();
+// The below code has been commented out in case it is necessary to fall back.
+/*
 	std::string text_str(text);
 	XmlEncode(text_str);
 	std::string final = "<speak>" + text_str + "</speak>";
@@ -47,7 +49,11 @@ bool NVDA::Speak(const char* text, bool interrupt) {
 	else {
 		return result == 0;
 	}
-	return false;
+*/
+	std::wstring out;
+	UnicodeConvert(text, out);
+	return nvdaController_speakText(out.c_str()) == 0;
+//	return false;
 }
 bool NVDA::SpeakSsml(const char* ssml, bool interrupt) {
 	if (!GetActive())return false;


### PR DESCRIPTION
This change fixes the problem with words containing apostrophes not speaking correctly with NVDA by changing the speak function to use the normal speak text function instead of speak ssml. This does not break the symbol level as thought. I tested it.