### PR TITLE
CMake & Meson refactor; add Orca, AccessKit

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -1,47 +1,84 @@
-name: CMake Build
+name: SRAL Build
 
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:
+    name: ${{ matrix.preset }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: windows-latest
+            preset: x64-release
+          - os: ubuntu-latest
+            preset: linux-release
+          - os: macos-latest
+            preset: macos-universal-release
+          - os: ubuntu-latest
+            preset: android-arm64-release
+          - os: ubuntu-latest
+            preset: linux-to-win-mingw
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+      
+      - name: Setup Windows Environment
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          mkdir -p Dep
+          Invoke-WebRequest -Uri "https://githubusercontent.com" -OutFile "Dep/nvda_control.h"
+          Invoke-WebRequest -Uri "https://githubusercontent.com" -OutFile "Dep/nvda_control.c"
 
-      - name: Set up CMake
-        uses: jwlawson/actions-setup-cmake@v2
+      - name: Set up MSVC
+        if: matrix.os == 'windows-latest'
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
+          arch: x64
           cmake-version: '3.25.0'
 
-      - name: Install packages
+          
+      - name: Install Linux/MinGW Dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libspeechd-dev libx11-dev brltty libbrlapi-dev
+          sudo apt-get install -y ninja-build pkg-config libspeechd-dev libbrlapi-dev libdbus-1-dev brltty
+          if [[ "${{ matrix.preset }}" == *"mingw"* ]]; then
+            sudo apt-get install -y g++-mingw-w64-x86-64
+          fi
+          
+      - name: Setup Android NDK
+        if: matrix.preset == 'android-arm64-release'
+        run: |
+          echo "ANDROID_NDK_HOME=${ANDROID_NDK_LATEST_HOME}" >> $GITHUB_ENV
+          
+      - name: Install Ninja (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install ninja
 
-
-
+    
       - name: Configure CMake
-        run: cmake . -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DBUILD_SHARED_LIBS=ON
-
-      - name: Build with CMake
-        run: cmake --build build --config Release -j 16
-
-
+        run: cmake --preset ${{ matrix.preset }}
+        
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+        
+      - name: Package Assets
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp Include/SRAL.h dist/
+          find out/build/${{ matrix.preset }} -name "*.lib" -o -name "*.dll" -o -name "*.a" -o -name "*.so" -exec cp {} dist/ \;
 
       - name: Archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.os }}-build
-          path: build
-
-
+          name: SRAL-${{ matrix.preset }}
+          path: dist/

--- a/Bindings/.Net/Program.cs
+++ b/Bindings/.Net/Program.cs
@@ -1,0 +1,52 @@
+class Program
+{
+    static void Main(string[] args)
+    {
+        try {
+            RunMainDemo();
+        }
+        catch (Exception e) {
+            Console.WriteLine($"Demo failed with error: {e.Message}");
+        }
+
+        ErrorHandlingDemo();
+    }
+
+    static void RunMainDemo()
+    {
+        using var sral = new SRAL();
+        Console.WriteLine("=== SRAL Library Demo ===");
+
+        if (!sral.IsInitialized()) {
+            Console.WriteLine("Initializing SRAL...");
+            if (!sral.Initialize()) {
+                Console.WriteLine("Failed to initialize SRAL!");
+                return;
+            }
+        }
+
+        Console.WriteLine("SRAL initialized successfully!");
+        var current = sral.GetCurrentEngine();
+        Console.WriteLine($"Current Engine: {sral.GetEngineName(current)}");
+
+        Console.WriteLine("Speaking basic text...");
+        sral.Speak("Hello, this is a test of the SRAL library.", true);
+
+        sral.Delay(1000);
+        Console.WriteLine("Cleaning up...");
+    }
+
+    static void ErrorHandlingDemo()
+    {
+        Console.WriteLine("\n=== Error Handling Demo ===");
+        try {
+            var sral = new SRAL();
+            Console.WriteLine("Attempting operation without initialization...");
+            bool result = sral.Speak("This might fail depending on library state", true);
+            Console.WriteLine($"Result: {result}");
+        }
+        catch (Exception e) {
+            Console.WriteLine($"Error caught: {e.Message}");
+        }
+    }
+}

--- a/Bindings/.Net/sral.cs
+++ b/Bindings/.Net/sral.cs
@@ -1,0 +1,119 @@
+using System.Runtime.InteropServices;
+
+namespace SRALBindings
+{
+    // --- Enums ---
+    [Flags]
+    public enum SRALEngine : int
+    {
+        None = 0, NVDA = 1 << 1, JAWS = 1 << 2, ZDSR = 1 << 3, Narrator = 1 << 4,
+        UIA = 1 << 5, SAPI = 1 << 6, SpeechDispatcher = 1 << 7, 
+        VoiceOver = 1 << 8, NSSpeech = 1 << 9, AVSpeech = 1 << 10
+    }
+
+    public enum SRALParam : int
+    {
+        SpeechRate = 0, SpeechVolume = 1, VoiceIndex = 2, VoiceProperties = 3,
+        VoiceCount = 4, SymbolLevel = 5, SapiTrimThreshold = 6, 
+        EnableSpelling = 7, UseCharacterDescriptions = 8, NvdaIsControlEx = 9
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    public struct SRALVoiceInfo
+    {
+        public int Index;
+        [MarshalAs(UnmanagedType.LPStr)] public string Name;
+        [MarshalAs(UnmanagedType.LPStr)] public string Language;
+        [MarshalAs(UnmanagedType.LPStr)] public string Gender;
+        [MarshalAs(UnmanagedType.LPStr)] public string Vendor;
+    }
+
+    // --- Native Methods ---
+    internal static partial class SRALNative
+    {
+        private const string LibName = "SRAL";
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_Initialize")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool Initialize(int enginesExclude);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_Uninitialize")]
+        public static partial void Uninitialize();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_IsInitialized")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool IsInitialized();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_Speak", StringMarshalling = StringMarshalling.Ansi)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool Speak([MarshalAs(UnmanagedType.LPStr)] string text, [MarshalAs(UnmanagedType.I1)] bool interrupt);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_SpeakSsml", StringMarshalling = StringMarshalling.Ansi)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool SpeakSsml([MarshalAs(UnmanagedType.LPStr)] string ssml, [MarshalAs(UnmanagedType.I1)] bool interrupt);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_SpeakToMemory", StringMarshalling = StringMarshalling.Ansi)]
+        public static partial IntPtr SpeakToMemory([MarshalAs(UnmanagedType.LPStr)] string text, ref ulong size, ref int ch, ref int rate, ref int bits);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_Braille", StringMarshalling = StringMarshalling.Ansi)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool Braille([MarshalAs(UnmanagedType.LPStr)] string text);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_Output", StringMarshalling = StringMarshalling.Ansi)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool Output([MarshalAs(UnmanagedType.LPStr)] string text, [MarshalAs(UnmanagedType.I1)] bool interrupt);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_StopSpeech")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool StopSpeech();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_PauseSpeech")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool PauseSpeech();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_ResumeSpeech")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool ResumeSpeech();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_IsSpeaking")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool IsSpeaking();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_GetCurrentEngine")]
+        public static partial int GetCurrentEngine();
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_GetEngineParameter")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool GetEngineParameter(int engine, int param, IntPtr value);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_SetEngineParameter")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static partial bool SetEngineParameter(int engine, int param, IntPtr value);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_GetEngineName")]
+        [return: MarshalAs(UnmanagedType.LPStr)]
+        public static partial string GetEngineName(int engine);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_free")]
+        public static partial void Free(IntPtr ptr);
+
+        [LibraryImport(LibName, EntryPoint = "SRAL_Delay")]
+        public static partial void Delay(int ms);
+    }
+
+    // --- High-Level Wrapper ---
+    public class SRAL : IDisposable
+    {
+        public bool Initialize(SRALEngine exclude = SRALEngine.None) => SRALNative.Initialize((int)exclude);
+        public void Uninitialize() => SRALNative.Uninitialize();
+        public bool IsInitialized() => SRALNative.IsInitialized();
+
+        public bool Speak(string text, bool interrupt = true) => SRALNative.Speak(text, interrupt);
+        public bool Stop() => SRALNative.StopSpeech();
+        public bool IsSpeaking() => SRALNative.IsSpeaking();
+        public string GetEngineName(SRALEngine engine) => SRALNative.GetEngineName((int)engine);
+        public SRALEngine GetCurrentEngine() => (SRALEngine)SRALNative.GetCurrentEngine();
+
+        public void Dispose() { if (IsInitialized()) Uninitialize(); }
+    }
+}

--- a/Bindings/Lua/main.lua
+++ b/Bindings/Lua/main.lua
@@ -1,0 +1,61 @@
+local status, err = pcall(main)
+if not status then
+    print("Demo failed with error: " .. tostring(err))
+end
+local SRAL = require("sral")
+local sral = SRAL.new()
+
+local function sleep(n)
+    if ffi.os == "Windows" then os.execute("timeout " .. n .. " > nul")
+    else os.execute("sleep " .. n) end
+end
+
+local function error_handling_demo()
+    print("\n=== Error Handling Demo ===")
+    local standalone = SRAL.new()
+    print("Attempting operation without initialization...")
+    local result = standalone:speak("This should fail", true)
+    print("Result: " .. tostring(result) .. " (expected: false)")
+end
+
+local function main()
+    print("=== SRAL Library Demo ===")
+    
+    if not sral:is_initialized() then
+        print("Initializing SRAL...")
+        if not sral:initialize() then
+            print("Failed to initialize SRAL!")
+            return
+        end
+    end
+
+    print("SRAL initialized successfully!")
+    
+    local current = sral:get_current_engine()
+    print("Active Engine: " .. sral:get_engine_name(current))
+
+    sral:speak_ex(current, "Lua bindings initialized. Testing keyboard hooks.", true)
+    
+    if sral:register_keyboard_hooks() then
+        print("Hooks active. Use Ctrl to stop or Shift to pause.")
+        sral:delay(2000)
+        sral:unregister_keyboard_hooks()
+    end
+
+    print("Speaking basic text...")
+    sral:speak("Hello from LuaJIT! Testing SRAL on " .. ffi.os, true)
+    
+    print("Is speaking: " .. tostring(sral:is_speaking()))
+    if ffi.os == "Windows" then os.execute("timeout /t 2 >nul") else os.execute("sleep 2") end
+
+    print("\nCleaning up...")
+    sral:uninitialize()
+    print("SRAL uninitialized successfully!")
+end
+
+local status, err = pcall(main)
+if not status then
+    print("Demo failed with error: " .. tostring(err))
+end
+
+error_handling_demo()

--- a/Bindings/Lua/sral.lua
+++ b/Bindings/Lua/sral.lua
@@ -1,0 +1,104 @@
+local ffi = require("ffi")
+
+local lib_name = ffi.os == "Windows" and "SRAL.dll" or (ffi.os == "OSX" and "libSRAL.dylib" or "libSRAL.so")
+local sral_lib = ffi.load(lib_name)
+
+ffi.cdef[[
+    typedef struct {
+        int index;
+        const char* name;
+        const char* language;
+        const char* gender;
+        const char* vendor;
+    } SRALVoiceInfo;
+
+    bool SRAL_Initialize(int enginesExclude);
+    void SRAL_Uninitialize();
+    bool SRAL_IsInitialized();
+    bool SRAL_Speak(const char* text, bool interrupt);
+    bool SRAL_SpeakSsml(const char* ssml, bool interrupt);
+    void* SRAL_SpeakToMemory(const char* text, uint64_t* size, int* ch, int* rate, int* bits);
+    bool SRAL_Braille(const char* text);
+    bool SRAL_Output(const char* text, bool interrupt);
+    bool SRAL_StopSpeech();
+    bool SRAL_PauseSpeech();
+    bool SRAL_ResumeSpeech();
+    bool SRAL_IsSpeaking();
+    int  SRAL_GetCurrentEngine();
+    int  SRAL_GetEngineFeatures(int engine);
+    bool SRAL_SetEngineParameter(int engine, int param, void* value);
+    bool SRAL_GetEngineParameter(int engine, int param, void* value);
+    const char* SRAL_GetEngineName(int engine);
+    int  SRAL_GetAvailableEngines();
+    int  SRAL_GetActiveEngines();
+    bool SRAL_RegisterKeyboardHooks();
+    void SRAL_UnregisterKeyboardHooks();
+    void SRAL_Delay(int ms);
+    bool SRAL_SetEnginesExclude(int enginesExclude);
+    int  SRAL_GetEnginesExclude();
+    void SRAL_free(void* ptr);
+
+    // Extended Functions
+    bool SRAL_SpeakEx(int engine, const char* text, bool interrupt);
+    bool SRAL_SpeakSsmlEx(int engine, const char* ssml, bool interrupt);
+    void* SRAL_SpeakToMemoryEx(int engine, const char* text, uint64_t* size, int* ch, int* rate, int* bits);
+    bool SRAL_BrailleEx(int engine, const char* text);
+    bool SRAL_OutputEx(int engine, const char* text, bool interrupt);
+    bool SRAL_StopSpeechEx(int engine);
+    bool SRAL_PauseSpeechEx(int engine);
+    bool SRAL_ResumeSpeechEx(int engine);
+    bool SRAL_IsSpeakingEx(int engine);
+]]
+
+local SRAL = {
+    -- Enum Tables
+    Engine = { NONE = 0, NVDA = 2, JAWS = 4, VOICE_OVER = 256, SAPI = 64 },
+    Param = { SPEECH_RATE = 0, VOICE_PROPERTIES = 3, VOICE_COUNT = 4, ENABLE_SPELLING = 7 }
+}
+SRAL.__index = SRAL
+
+function SRAL.new()
+    return setmetatable({ _lib = sral_lib }, SRAL)
+end
+
+-- --- Utility & Core ---
+function SRAL:initialize(ex) return self._lib.SRAL_Initialize(ex or 0) end
+function SRAL:uninitialize() self._lib.SRAL_Uninitialize() end
+function SRAL:is_initialized() return self._lib.SRAL_IsInitialized() end
+function SRAL:delay(ms) self._lib.SRAL_Delay(ms) end
+function SRAL:get_engine_name(e) return ffi.string(self._lib.SRAL_GetEngineName(e)) end
+
+-- --- Extended Speech Operations ---
+function SRAL:resume_speech_ex(e) return self._lib.SRAL_ResumeSpeechEx(e) end
+function SRAL:is_speaking_ex(e) return self._lib.SRAL_IsSpeakingEx(e) end
+function SRAL:speak_ex(e, txt, int) return self._lib.SRAL_SpeakEx(e, txt, int == nil or int) end
+
+-- --- Hooks & Engine Management ---
+function SRAL:register_keyboard_hooks() return self._lib.SRAL_RegisterKeyboardHooks() end
+function SRAL:unregister_keyboard_hooks() self._lib.SRAL_UnregisterKeyboardHooks() end
+function SRAL:get_available_engines() return self._lib.SRAL_GetAvailableEngines() end
+function SRAL:get_active_engines() return self._lib.SRAL_GetActiveEngines() end
+function SRAL:set_engines_exclude(ex) return self._lib.SRAL_SetEnginesExclude(ex) end
+function SRAL:get_engines_exclude() return self._lib.SRAL_GetEnginesExclude() end
+
+-- --- Parameter Handling (VOICE_PROPERTIES Logic) ---
+function SRAL:get_engine_parameter(engine, param)
+    if param == self.Param.VOICE_COUNT then
+        local val = ffi.new("int")
+        if self._lib.SRAL_GetEngineParameter(engine, param, val) then return tonumber(val[0]) end
+    elseif param == self.Param.VOICE_PROPERTIES then
+        local count = self:get_engine_parameter(engine, self.Param.VOICE_COUNT) or 0
+        if count <= 0 then return {} end
+        local voices = ffi.new("SRALVoiceInfo[?]", count)
+        if self._lib.SRAL_GetEngineParameter(engine, param, voices) then
+            local res = {}
+            for i = 0, count - 1 do
+                table.insert(res, { index = voices[i].index, name = ffi.string(voices[i].name), lang = ffi.string(voices[i].language) })
+            end
+            return res
+        end
+    end
+    return nil
+end
+
+return SRAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,66 +1,105 @@
-﻿# CMakeLists.txt : CMake project for SRAL, include source and define
-# project specific logic here.
-#
-cmake_minimum_required (VERSION 3.25)
-set(CMAKE_CXX_STANDARD 20)
+﻿cmake_minimum_required (VERSION 3.25)
+project ("SRAL" LANGUAGES C CXX)
 
-# Allow runtime library to be set externally; default to dynamic if not set
+set(CMAKE_CXX_STANDARD 20)
+set(INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/Include")
+
+# Target-specific MSVC warnings (TODO implemented)
+if(MSVC)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
+# MSVC Runtime and Hot Reload
 if(NOT CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
-set(INCLUDES "Include")
-
-# Enable Hot Reload for MSVC compilers if supported.
-if (MSVC)
-if (POLICY CMP0141)
+if (MSVC AND POLICY CMP0141)
   cmake_policy(SET CMP0141 NEW)
   set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<IF:$<AND:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>,$<$<CONFIG:Debug,RelWithDebInfo>:EditAndContinue>,$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>>")
 endif()
-endif()
 
-project ("SRAL")
+# Options
 option (BUILD_SRAL_TEST "Build SRAL examples/tests" ON)
 option (SRAL_DISABLE_UIA "Disable UIA (UI Automation) support" OFF)
 option (SRAL_DISABLE_NSSPEECH "Disable NSSpeech (macOS-only NSSpeechSynthesizer) support" OFF)
+
+# Core Object Library
 add_library(${PROJECT_NAME}_obj OBJECT)
-target_sources(${PROJECT_NAME}_obj PRIVATE
-  "SRC/Encoding.h" "SRC/Encoding.cpp"
+target_sources(${PROJECT_NAME}_obj PRIVATE 
+  "SRC/Encoding.h" "SRC/Encoding.cpp" 
   "SRC/SRAL.cpp" "SRC/Engine.h" "SRC/Engine.cpp")
-target_sources(${PROJECT_NAME}_obj PUBLIC
-  FILE_SET HEADERS
-  BASE_DIRS "${INCLUDES}"
+
+target_sources(${PROJECT_NAME}_obj PUBLIC 
+  FILE_SET HEADERS 
+  BASE_DIRS "${INCLUDES}" 
   FILES "${INCLUDES}/SRAL.h")
+
+# --- Platform Specific Source Selection & Dependency Checks ---
+
 if(WIN32)
-  target_sources(${PROJECT_NAME}_obj PRIVATE
+  # Standard Windows Engines
+  target_sources(${PROJECT_NAME}_obj PRIVATE 
     "SRC/NVDA.h" "SRC/NVDA.cpp" "SRC/SAPI.h" "SRC/SAPI.cpp"
-    "Dep/blastspeak.h" "Dep/blastspeak.c" "Dep/fsapi.h" "Dep/fsapi.c" "Dep/nvda_control.h" "Dep/nvda_control.c"
-    "SRC/Jaws.h" "SRC/Jaws.cpp"
+    "Dep/blastspeak.h" "Dep/blastspeak.c" "Dep/fsapi.h" "Dep/fsapi.c" 
+    "Dep/nvda_control.h" "Dep/nvda_control.c"
+    "SRC/Jaws.h" "SRC/Jaws.cpp" 
     "Dep/wasapi.h" "Dep/wasapi.cpp" "SRC/ZDSR.h" "SRC/ZDSR.cpp")
+
+  # Optional UIA
   if(NOT SRAL_DISABLE_UIA)
-    target_sources(${PROJECT_NAME}_obj PRIVATE
-      "SRC/UIA.cpp" "Dep/UIAProvider.h" "Dep/UIAProvider.cpp")
+    target_sources(${PROJECT_NAME}_obj PRIVATE "SRC/UIA.cpp" "Dep/UIAProvider.h" "Dep/UIAProvider.cpp")
+    target_link_libraries(${PROJECT_NAME}_obj PRIVATE "uiautomationcore.lib")
   endif()
+
+  # Check for AccessKit
+  find_library(ACCESSKIT_LIB NAMES accesskit)
+  if(ACCESSKIT_LIB)
+    message(STATUS "AccessKit found: ${ACCESSKIT_LIB}")
+    target_sources(${PROJECT_NAME}_obj PRIVATE "SRC/ACAnnouncer.h" "SRC/ACAnnouncer.cpp")
+    target_link_libraries(${PROJECT_NAME}_obj PRIVATE ${ACCESSKIT_LIB})
+  else()
+    message(STATUS "AccessKit not found. ACAnnouncer will be disabled.")
+    target_compile_definitions(${PROJECT_NAME}_obj PRIVATE SRAL_NO_ACCESSKIT)
+  endif()
+
+  target_link_libraries(${PROJECT_NAME}_obj PRIVATE "ole32.lib" "user32.lib")
+
 elseif(APPLE)
-  target_sources(${PROJECT_NAME}_obj PRIVATE
-    "SRC/AVSpeech.h" "SRC/AVSpeech.mm" "SRC/VoiceOver.h" "SRC/VoiceOver.mm")
+  enable_language(OBJC OBJCXX)
+  target_sources(${PROJECT_NAME}_obj PRIVATE "SRC/AVSpeech.h" "SRC/AVSpeech.mm" "SRC/VoiceOver.h" "SRC/VoiceOver.mm")
+  
   if(NOT SRAL_DISABLE_NSSPEECH)
-    target_sources(${PROJECT_NAME}_obj PRIVATE
-      "SRC/NSSpeech.h" "SRC/NSSpeech.mm")
+    target_sources(${PROJECT_NAME}_obj PRIVATE "SRC/NSSpeech.h" "SRC/NSSpeech.mm")
   endif()
+
+  target_link_libraries(${PROJECT_NAME}_obj INTERFACE "-framework AppKit" "-framework Foundation" "-framework AVFoundation")
+
 elseif(ANDROID)
-  target_sources(${PROJECT_NAME}_obj PRIVATE
+  target_sources(${PROJECT_NAME}_obj PRIVATE 
     "SRC/AndroidTextToSpeech.h" "SRC/AndroidTextToSpeech.cpp"
     "SRC/AndroidAccessibilityManager.h" "SRC/AndroidAccessibilityManager.cpp"
     "Dep/AndroidContext.h" "Dep/AndroidContext.cpp")
-else()
-  target_sources(${PROJECT_NAME}_obj PRIVATE
-     "Dep/utf-8.h" "Dep/utf-8.c" "SRC/SpeechDispatcher.h" "SRC/SpeechDispatcher.cpp")
+  
+  target_link_libraries(${PROJECT_NAME}_obj PRIVATE log)
+
+else() # Linux
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(SpeechD REQUIRED speech-dispatcher)
+  pkg_check_modules(DBUS REQUIRED dbus-1)
+  find_library(BRLAPI "brlapi" REQUIRED)
+
+  target_sources(${PROJECT_NAME}_obj PRIVATE 
+    "Dep/utf-8.h" "Dep/utf-8.c" 
+    "SRC/SpeechDispatcher.h" "SRC/SpeechDispatcher.cpp"
+    "SRC/Orca.h" "SRC/Orca.cpp")
+
+  target_link_libraries(${PROJECT_NAME}_obj PRIVATE ${SpeechD_LIBRARIES} ${DBUS_LIBRARIES} ${BRLAPI})
+  target_include_directories(${PROJECT_NAME}_obj PRIVATE ${SpeechD_INCLUDE_DIRS} ${DBUS_INCLUDE_DIRS})
 endif()
 
-set_property(TARGET ${PROJECT_NAME}_obj
-  PROPERTY POSITION_INDEPENDENT_CODE on)
-# TODO: Probably we shouldn't simply suppress these warnings
-target_compile_definitions(${PROJECT_NAME}_obj PRIVATE _CRT_SECURE_NO_WARNINGS)
+set_property(TARGET ${PROJECT_NAME}_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# Feature-based Definitions
 if(SRAL_DISABLE_UIA)
   target_compile_definitions(${PROJECT_NAME}_obj PRIVATE SRAL_NO_UIA)
 endif()
@@ -68,101 +107,41 @@ if(SRAL_DISABLE_NSSPEECH)
   target_compile_definitions(${PROJECT_NAME}_obj PRIVATE SRAL_NO_NSSPEECH)
 endif()
 
+# --- Library Targets ---
+
+# Static Library
+add_library(${PROJECT_NAME}_static STATIC $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
+target_include_directories(${PROJECT_NAME}_static PUBLIC 
+    $<BUILD_INTERFACE:${INCLUDES}> 
+    $<INSTALL_INTERFACE:include>)
+# Inherit private links from object library
+target_link_libraries(${PROJECT_NAME}_static PRIVATE $<TARGET_PROPERTY:${PROJECT_NAME}_obj,LINK_LIBRARIES>)
+
+# Shared Library (Optional)
 if(BUILD_SHARED_LIBS)
-  add_library(${PROJECT_NAME} SHARED
-  $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
-  endif()
-
-add_library(${PROJECT_NAME}_static STATIC
-  $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
-
-  if(BUILD_SHARED_LIBS)
-target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDES})
+  add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
+  target_include_directories(${PROJECT_NAME} PUBLIC 
+    $<BUILD_INTERFACE:${INCLUDES}> 
+    $<INSTALL_INTERFACE:include>)
+  target_link_libraries(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:${PROJECT_NAME}_obj,LINK_LIBRARIES>)
 endif()
 
-target_include_directories(${PROJECT_NAME}_static PUBLIC ${INCLUDES})
+# --- Examples / Tests ---
 
-install(TARGETS ${PROJECT_NAME}_obj FILE_SET HEADERS
-  INCLUDES DESTINATION "include")
+if (BUILD_SRAL_TEST)
+  add_executable(${PROJECT_NAME}_test "Examples/C/SRALExample.c")
+  target_link_libraries(${PROJECT_NAME}_test PRIVATE ${PROJECT_NAME}_static)
 
-  if(BUILD_SHARED_LIBS)
-install(TARGETS ${PROJECT_NAME}
-  RUNTIME DESTINATION "bin"
-  LIBRARY DESTINATION "lib"
-  ARCHIVE DESTINATION "lib")
+  if(APPLE)
+     add_executable(${PROJECT_NAME}_test_cocoa "Examples/ObjC/SRALCocoaExample.m")
+     target_link_libraries(${PROJECT_NAME}_test_cocoa PRIVATE ${PROJECT_NAME}_static)
   endif()
+endif()
 
+# --- Installation ---
+
+install(TARGETS ${PROJECT_NAME}_obj FILE_SET HEADERS DESTINATION "include")
 install(TARGETS ${PROJECT_NAME}_static DESTINATION "lib")
-
-
-if (BUILD_SRAL_TEST)
-add_executable(${PROJECT_NAME}_test "Examples/C/SRALExample.c" "Include/SRAL.h")
-
-target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME}_static)
-
-endif()
-if (WIN32)
-if (BUILD_SRAL_TEST)
- add_executable(${PROJECT_NAME}_NVDAControleExConsole "Examples/C/NVDAControlExConsole.c" "Dep/nvda_control.c")
-endif()
- if(NOT SRAL_DISABLE_UIA)
-   set(LIBS "uiautomationcore.lib")
-   if(BUILD_SHARED_LIBS)
-    target_link_libraries(${PROJECT_NAME} ${LIBS})
-   endif()
-   target_link_libraries(${PROJECT_NAME}_static ${LIBS})
- endif()
-elseif (APPLE)
-  enable_language(OBJC)
-  enable_language(OBJCXX)
-  set(CMAKE_C_COMPILER clang)
-  set(CMAKE_CXX_COMPILER clang++)
-  if(BUILD_SHARED_LIBS)
-  target_link_libraries(${PROJECT_NAME}
-    "-framework AppKit"
-    "-framework Foundation"
-    "-framework AVFoundation"
-  )
-  endif()
-
-if (BUILD_SRAL_TEST)
-  target_link_libraries(${PROJECT_NAME}_test
-    "-framework AppKit"
-    "-framework Foundation"
-    "-framework AVFoundation"
-  )
-
-  add_executable(${PROJECT_NAME}_test_cocoa "Examples/ObjC/SRALCocoaExample.m" "Include/SRAL.h")
-  target_link_libraries(${PROJECT_NAME}_test_cocoa
-    ${PROJECT_NAME}_static
-    "-framework AppKit"
-    "-framework Foundation"
-    "-framework AVFoundation"
-  )
-endif()
-elseif(ANDROID)
-  if(BUILD_SHARED_LIBS)
-    target_link_libraries(${PROJECT_NAME} log)
-  endif()
-  target_link_libraries(${PROJECT_NAME}_static log)
-else()
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(SpeechD REQUIRED speech-dispatcher)
-
-  if(BUILD_SHARED_LIBS)
-  target_link_libraries(${PROJECT_NAME} ${SpeechD_LIBRARIES})
-  endif()
-if (BUILD_SRAL_TEST)
-  target_link_libraries(${PROJECT_NAME}_test ${SpeechD_LIBRARIES})
-
-endif()
-find_library(BRLAPI "libbrlapi.so")
-  set(LIBS "${BRLAPI}")
-  if(BUILD_SHARED_LIBS)
-  target_link_libraries(${PROJECT_NAME} ${LIBS})
-  endif()
-if (BUILD_SRAL_TEST)
-  target_link_libraries(${PROJECT_NAME}_test ${LIBS})
-endif()
-
+if(BUILD_SHARED_LIBS)
+  install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "bin" LIBRARY DESTINATION "lib" ARCHIVE DESTINATION "lib")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,13 +2,20 @@
   "version": 3,
   "configurePresets": [
     {
-      "name": "windows-base",
+      "name": "base",
       "hidden": true,
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
-      },
+        "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_SRAL_TEST": "ON"
+      }
+    },
+    {
+      "name": "windows-base",
+      "hidden": true,
+      "inherits": "base",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -23,17 +30,13 @@
         "value": "x64",
         "strategy": "external"
       },
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
     },
     {
       "name": "x64-release",
       "displayName": "x64 Release",
       "inherits": "x64-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
     },
     {
       "name": "x86-debug",
@@ -43,33 +46,27 @@
         "value": "x86",
         "strategy": "external"
       },
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
     },
     {
       "name": "x86-release",
       "displayName": "x86 Release",
       "inherits": "x86-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
     },
     {
       "name": "linux-debug",
       "displayName": "Linux Debug",
-      "description": "Target the Windows Subsystem for Linux (WSL) or a remote Linux system.",
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}",
-      "cacheVariables": {},
+      "description": "Target WSL or a remote Linux system.",
+      "inherits": "base",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
       },
       "vendor": {
-        "microsoft.com/VisualStudioRemoteSettings/CMake/2.0": {
+        "://microsoft.com": {
           "remoteSourceRootDir": "$env{HOME}/.vs/$ms{projectDirName}",
           "copyBuildOutput": true
         }
@@ -79,8 +76,67 @@
       "name": "linux-release",
       "displayName": "Linux Release",
       "inherits": "linux-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "macos-base",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "macos-universal-release",
+      "displayName": "macOS Universal Release",
+      "inherits": "macos-base",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
+      }
+    },
+    {
+      "name": "android-base",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Android",
+        "ANDROID_PLATFORM": "android-24",
+        "CMAKE_ANDROID_STL_TYPE": "c++_static",
+        "CMAKE_TOOLCHAIN_FILE": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake"
+      }
+    },
+    {
+      "name": "android-arm64-debug",
+      "displayName": "Android arm64-v8a Debug",
+      "inherits": "android-base",
+      "cacheVariables": {
+        "ANDROID_ABI": "arm64-v8a",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "android-arm64-release",
+      "displayName": "Android arm64-v8a Release",
+      "inherits": "android-arm64-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "linux-to-win-mingw",
+      "displayName": "Linux to Windows (MinGW) Cross",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Windows",
+        "CMAKE_C_COMPILER": "x86_64-w64-mingw32-gcc",
+        "CMAKE_CXX_COMPILER": "x86_64-w64-mingw32-g++",
         "CMAKE_BUILD_TYPE": "Release"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ SRAL supports Windows, macOS, iOS, Android, and Linux.
 | Category | Supported Engines |
 | --- | --- |
 | **Windows Screen Readers** | NVDA, JAWS, ZDSR, Microsoft Narrator |
-| **Windows Frameworks** | Microsoft UI Automation (UIA) |
+| **Windows Frameworks** | Microsoft UI Automation (UIA) | AccessKit Announcer (UIA) |
 | **macOS** | VoiceOver, NSSpeech, AVFoundation (AVSpeech) |
 | **iOS** | VoiceOver, AVFoundation (AVSpeech) |
 | **Android** | Android TextToSpeech, Android AccessibilityManager (TalkBack etc.) |
-| **Linux** | Speech Dispatcher |
+| **Linux** | Speech Dispatcher | Orca (D-Bus) |
 | **General APIs** | Microsoft SAPI (Windows), BRLTTY (Braille) |
 
 ---
@@ -60,14 +60,21 @@ When you initialize the library, SRAL loads all available and supported engines.
 
 SRAL uses CMake and can be built as either a static or dynamic library.
 
+**Windows Requirements:**
+You must have either `nvdaControllerClient.dll` (standard) or `NVDAControlEx` (extended) for NVDA support.
+
 **Linux Requirements:**
-You must install the following packages: `libspeechd-dev`, `libbrlapi-dev`, and `brltty`.
+You must install the following packages: `libspeechd-dev`, `libbrlapi-dev`, `libdbus-1-dev` and `brltty`.
 
 **Build Commands:**
 
 ```bash
-cmake . -B build
-cmake --build build --config Release
+# List available platforms (Windows, Linux, Android, macOS)
+cmake --list-presets
+
+# Configure and Build
+cmake --preset x64-release
+cmake --build out/build/x64-release
 
 ```
 
@@ -101,7 +108,8 @@ For C++ developers, a convenient inline wrapper is available in `Include/SRAL.hp
 ### Language Bindings
 
 * **Python**: Currently supported and available in the repository.
-* **LUA**: Bindings are currently in preparation and coming soon.
+* **LUA**: Currently supported and available in the repository.
+* **C#**: Currently supported and available in the repository.
 
 ---
 

--- a/SRC/ACAnnouncer.cpp
+++ b/SRC/ACAnnouncer.cpp
@@ -1,32 +1,50 @@
 #include "ACAnnouncer.h"
 #include <iostream>
 
-bool ACAnnouncer::Speak(const char* text, bool interrupt) {
-	static accesskit_tree tree = accesskit_tree_new(WINDOW_ID);
-	static accesskit_windows_adapter adapter = accesskit_windows_adapter_new(GetForegroundWindow(), true, [](struct accesskit_action_request* request, void* userdata) {
-		accesskit_action_request_free(request);
-		}, nullptr);
+static accesskit_windows_adapter* g_acAdapter = nullptr;
 
+bool ACAnnouncer::Initialize() {
+	if (g_acAdapter) return true;
+
+	g_acAdapter = accesskit_windows_adapter_new(
+		GetForegroundWindow(),
+		true,
+		[](struct accesskit_action_request* request, void* userdata) {
+			accesskit_action_request_free(request);
+		},
+		nullptr
+	);
+
+	return g_acAdapter != nullptr;
+}
+
+bool ACAnnouncer::Uninitialize() {
+	if (g_acAdapter) {
+		accesskit_windows_adapter_free(g_acAdapter);
+		g_acAdapter = nullptr;
+	}
+	return true;
+}
+
+bool ACAnnouncer::Speak(const char* text, bool interrupt) {
+	if (!g_acAdapter || !text) return false;
 	accesskit_node* window_node = accesskit_node_new(ACCESSKIT_ROLE_WINDOW);
-	accesskit_node* announcement_node = accesskit_node_new(ACCESSKIT_ROLE_LABEL);
-	accesskit_tree_update* update = accesskit_tree_update_with_capacity_and_focus(2, ANNOUNCEMENT_ID);
+	accesskit_node* announcement_node = accesskit_node_new(ACCESSKIT_ROLE_STATUS);
 
 	accesskit_node_set_label(announcement_node, text);
+	accesskit_node_set_live(announcement_node, interrupt ? ACCESSKIT_LIVE_ASSERTIVE : ACCESSKIT_LIVE_POLITE);
 
-	if (interrupt) {
-		accesskit_node_set_live(announcement_node, ACCESSKIT_LIVE_ASSERTIVE);
-	}
-	else {
-		accesskit_node_set_live(announcement_node, ACCESSKIT_LIVE_POLITE);
-	}
 	accesskit_node_push_child(window_node, ANNOUNCEMENT_ID);
+
+	accesskit_tree_update* update = accesskit_tree_update_with_capacity_and_focus(2, ANNOUNCEMENT_ID);
+
+	accesskit_tree* tree = accesskit_tree_new(WINDOW_ID);
+	accesskit_tree_update_set_tree(update, tree);
 
 	accesskit_tree_update_push_node(update, WINDOW_ID, window_node);
 	accesskit_tree_update_push_node(update, ANNOUNCEMENT_ID, announcement_node);
 
-	accesskit_windows_adapter_update_if_active(&adapter, [](void* userdata) {
-		return (accesskit_tree_update*)userdata;
-		}, update);
+	accesskit_windows_adapter_update_if_active(g_acAdapter, update);
 
 	return true;
 }
@@ -36,13 +54,5 @@ bool ACAnnouncer::StopSpeech() {
 }
 
 bool ACAnnouncer::GetActive() {
-	return true;
-}
-
-bool ACAnnouncer::Initialize() {
-	return true;
-}
-
-bool ACAnnouncer::Uninitialize() {
-	return true;
+	return g_acAdapter != nullptr && accesskit_windows_adapter_is_active(g_acAdapter);
 }

--- a/SRC/AVSpeech.mm
+++ b/SRC/AVSpeech.mm
@@ -11,7 +11,7 @@ public:
 	AVSpeechSynthesisVoice* currentVoice;
 	AVSpeechUtterance* utterance;
 
-	AVSpeechSynthesizerWrapper() : rate(0), volume(1), synth(nullptr), currentVoice(nullptr), utterance(nullptr) {}
+	AVSpeechSynthesizerWrapper() : rate(AVSpeechUtteranceDefaultSpeechRate), volume(1), synth(nullptr), currentVoice(nullptr), utterance(nullptr) {}
 AVSpeechSynthesisVoice* getVoiceObject(NSString* name){
  NSArray<AVSpeechSynthesisVoice*>* voices = [AVSpeechSynthesisVoice speechVoices];
  for (AVSpeechSynthesisVoice* v in voices) {
@@ -21,31 +21,72 @@ AVSpeechSynthesisVoice* getVoiceObject(NSString* name){
 }
 
 bool Initialize() {
- currentVoice = [AVSpeechSynthesisVoice voiceWithLanguage:@"en-US"]; //choosing english as a default language
- utterance = [[AVSpeechUtterance alloc] initWithString:@""];
- rate = utterance.rate;
- volume = utterance.volume;
- synth = [[AVSpeechSynthesizer alloc] init];
- return true;
+	bool Initialize() {
+    currentVoice = [AVSpeechSynthesisVoice voiceWithLanguage:@"en-US"];
+    if (currentVoice == nil) {
+        currentVoice = [AVSpeechSynthesisVoice voiceWithLanguage:[[NSLocale currentLocale] localeIdentifier]];
+    }
+    
+    if (currentVoice == nil && [[AVSpeechSynthesisVoice speechVoices] count] > 0) {
+        currentVoice = [[AVSpeechSynthesisVoice speechVoices] firstObject];
+    }
+
+    synth = [[AVSpeechSynthesizer alloc] init];
+    AVSpeechUtterance *tempUtterance = [[AVSpeechUtterance alloc] initWithString:@""];
+    rate = tempUtterance.rate;
+    volume = tempUtterance.volume;
+    
+    return (synth != nil && currentVoice != nil);
 }
-bool Uninitialize(){
- return true;
+}
+bool Uninitialize() {
+    if (synth != nil) {
+        [synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+        
+        #if !__has_feature(objc_arc)
+        [synth release];
+        [currentVoice release];
+        [utterance release];
+        #endif
+        
+        synth = nil;
+        currentVoice = nil;
+        utterance = nil;
+    }
+    return true;
 }
 
-bool Speak(const char* text, bool interrupt){
-  if (synth == nil) return false;
-  if (interrupt && synth.isSpeaking) {
-    [synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
-  }
-  NSString *nstext = [NSString stringWithUTF8String:text];
-  if (nstext == nil) return false;
-  AVSpeechUtterance *utterance = [[AVSpeechUtterance alloc] initWithString:nstext];
-  utterance.rate = rate;
-  utterance.volume = volume;
-  utterance.voice = currentVoice;
-  this->utterance = utterance;
-  [synth speakUtterance:this->utterance];
-  return true; // because IsSpeaking hasn't changed yet
+bool Speak(const char* text, bool interrupt) {
+    if (!synth || !text) return false;
+
+    NSString *nstext = [NSString stringWithUTF8String:text];
+    if (!nstext) return false;
+
+    if (interrupt) {
+        [synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+    }
+
+    AVSpeechUtterance *newUtterance = [[AVSpeechUtterance alloc] initWithString:nstext];
+    newUtterance.rate = this->rate;
+    newUtterance.volume = this->volume;
+    newUtterance.voice = this->currentVoice;
+
+#if !__has_feature(objc_arc)
+    if (this->utterance) {
+        [this->utterance release];
+    }
+    this->utterance = newUtterance;
+#else
+    this->utterance = newUtterance;
+#endif
+
+    [synth speakUtterance:newUtterance];
+    
+#if !__has_feature(objc_arc)
+    // [newUtterance release];
+#endif
+
+    return true;
 }
 
 bool StopSpeech(){
@@ -59,17 +100,32 @@ bool IsSpeaking() {
 bool GetActive(){
  return synth != nil;
 }
-void SetVolume(int value){
- this->volume = value;
+void SetVolume(int value) {
+    float vol = (float)value / 100.0f;
+    if (vol > 1.0f) vol = 1.0f;
+    if (vol < 0.0f) vol = 0.0f;
+    this->volume = vol;
 }
-int GetVolume(){
- return this->volume;
+
+int GetVolume() {
+    return (int)(this->volume * 100.0f + 0.5f);
 }
-void SetRate(int value){
- this->rate = value;
+
+void SetRate(int value) {
+    float min = AVSpeechUtteranceMinimumSpeechRate;
+    float max = AVSpeechUtteranceMaximumSpeechRate;
+
+    this->rate = min + ((float)value / 100.0f) * (max - min);
 }
-int GetRate(){
- return this->rate;
+
+int GetRate() {
+    float min = AVSpeechUtteranceMinimumSpeechRate;
+    float max = AVSpeechUtteranceMaximumSpeechRate;
+    
+    if (max == min) return 50;
+    return (int)(((this->rate - min) / (max - min)) * 100.0f + 0.5f);
+}
+
 }
 uint64_t GetVoiceCount(){
  NSArray<AVSpeechSynthesisVoice *> *voices = [AVSpeechSynthesisVoice speechVoices];
@@ -115,26 +171,41 @@ bool AvSpeech::GetActive() {
 }
 
 bool AvSpeech::Speak(const char* text, bool interrupt) {
-	return obj->Speak(text, interrupt);
+	return obj ?  obj->Speak(text, interrupt) : false;
 }
 
 bool AvSpeech::StopSpeech() {
-	return obj->StopSpeech();
+	return obj ? obj->StopSpeech() : false;
 }
 bool AvSpeech::IsSpeaking() {
-	return obj->IsSpeaking();
+	return obj ? obj->IsSpeaking() : false;
 }
 
 bool AvSpeech::SetParameter(int param, const void* value) {
+	if (!obj || !value) return false;
+	 int val = *reinterpret_cast<const int*>(value);
 	switch (param) {
 	case SRAL_PARAM_SPEECH_RATE:
-		obj->SetRate(*reinterpret_cast<const int*>(value));
+		obj->SetRate(val);
 		return true;
 	case SRAL_PARAM_SPEECH_VOLUME:
-		obj->SetVolume(*reinterpret_cast<const int*>(value));
+		obj->SetVolume(val);
 		return true;
-	case SRAL_PARAM_VOICE_INDEX:
-		return obj->SetVoice(*reinterpret_cast<const int*>(value));
+	case SRAL_PARAM_VOICE_INDEX: {
+            AVSpeechSynthesisVoice* v = obj->GetVoice(val);
+            if (v) {
+                #if !__has_feature(objc_arc)
+                if (obj->currentVoice != v) {
+                    [obj->currentVoice release];
+                    obj->currentVoice = [v retain];
+                }
+                #else
+                obj->currentVoice = v;
+                #endif
+                return true;
+            }
+            return false;
+        }
 	default:
 		return false;
 	}
@@ -142,29 +213,49 @@ bool AvSpeech::SetParameter(int param, const void* value) {
 }
 
 bool AvSpeech::GetParameter(int param, void* value) {
-	switch (param) {
-	case SRAL_PARAM_SPEECH_RATE: {
-		*(int*)value = obj->GetRate();
-		return true;
-	}
-	case SRAL_PARAM_SPEECH_VOLUME: {
-		*(int*)value = obj->GetVolume();
-		return true;
-	}
-	case SRAL_PARAM_VOICE_PROPERTIES: {
-		ReleaseAllStrings();
-		int voice_count = obj->GetVoiceCount();
-		SRAL_VoiceInfo* voices = (SRAL_VoiceInfo*)value;
-		for (int i = 0; i < voice_count; ++i) {
-			const char* desc = obj->GetVoiceName(i);
-			voices[i].name = AddString(desc);
-		}
-	return true;
-	}
-	default:
-		return false;
-	}
-	return true;
+    if (!obj || !value) return false;
+
+    switch (param) {
+    case SRAL_PARAM_SPEECH_RATE:
+        *(int*)value = obj->GetRate();
+        return true;
+
+    case SRAL_PARAM_SPEECH_VOLUME:
+        *(int*)value = obj->GetVolume();
+        return true;
+
+    case SRAL_PARAM_VOICE_COUNT:
+        *(int*)value = (int)obj->GetVoiceCount();
+        return true;
+
+    case SRAL_PARAM_VOICE_PROPERTIES: {
+        ReleaseAllStrings();
+        int voice_count = (int)obj->GetVoiceCount();
+        SRAL_VoiceInfo* voices_info = static_cast<SRAL_VoiceInfo*>(value);
+        
+        NSArray<AVSpeechSynthesisVoice*>* voices = [AVSpeechSynthesisVoice speechVoices];
+        
+        for (int i = 0; i < voice_count; ++i) {
+            AVSpeechSynthesisVoice* v = [voices objectAtIndex:i];
+            
+            voices_info[i].index = i;
+            voices_info[i].name = AddString([v.name UTF8String]);
+            voices_info[i].language = AddString([v.language UTF8String]);
+            
+            if (v.gender == AVSpeechSynthesisVoiceGenderMale)
+                voices_info[i].gender = AddString("Male");
+            else if (v.gender == AVSpeechSynthesisVoiceGenderFemale)
+                voices_info[i].gender = AddString("Female");
+            else
+                voices_info[i].gender = AddString("Unknown");
+
+            voices_info[i].vendor = AddString("Apple");
+        }
+        return true;
+    }
+    default:
+        return false;
+    }
 }
 
 }

--- a/SRC/Jaws.cpp
+++ b/SRC/Jaws.cpp
@@ -6,10 +6,7 @@ namespace Sral {
 
 	bool Jaws::Initialize() {
 		HRESULT hr = CoCreateInstance(CLSID_JawsApi, NULL, CLSCTX_INPROC_SERVER, IID_IJawsApi, (void**)&pJawsApi);
-		if (!pJawsApi || FAILED(hr)) {
-			return false;
-		}
-		return true;
+		return (SUCCEEDED(hr) && pJawsApi != nullptr);
 	}
 	bool Jaws::Uninitialize() {
 		if (pJawsApi) {
@@ -27,12 +24,12 @@ namespace Sral {
 		if (interrupt)pJawsApi->StopSpeech();
 		std::wstring str;
 		UnicodeConvert(text, str);
-		const BSTR bstr = SysAllocString(str.c_str());
+		BSTR bstr = SysAllocString(str.c_str());
+		if (!bstr) return false;
 		VARIANT_BOOL result = VARIANT_FALSE;
-		const VARIANT_BOOL flush = interrupt ? VARIANT_TRUE : VARIANT_FALSE;
-		const bool succeeded = SUCCEEDED(pJawsApi->SayString(bstr, flush, &result));
+		HRESULT hr = pJawsApi->SayString(bstr, interrupt ? VARIANT_TRUE : VARIANT_FALSE, &result);
 		SysFreeString(bstr);
-		return (succeeded && result == VARIANT_TRUE);
+		return (SUCCEEDED(hr) && result == VARIANT_TRUE);
 	}
 	bool Jaws::Braille(const char* text) {
 		if (!GetActive())return false;
@@ -43,13 +40,14 @@ namespace Sral {
 			wstr[i] = L'\'';
 			i = wstr.find_first_of(L"\"", i + 1);
 		}
-		wstr.insert(0, L"BrailleString(\"");
-		wstr.append(L"\")");
-		const BSTR bstr = SysAllocString(wstr.c_str());
+		BSTR bstr = SysAllocString(wstr.c_str());
+		if (!bstr) return false;
+
 		VARIANT_BOOL result = VARIANT_FALSE;
+		HRESULT hr = pJawsApi->RunFunction(bstr, &result);
 		SysFreeString(bstr);
-		const bool succeeded = SUCCEEDED(pJawsApi->RunFunction(bstr, &result));
-		return (succeeded && result == VARIANT_TRUE);
+
+		return (SUCCEEDED(hr) && result == VARIANT_TRUE);
 	}
 
 	bool Jaws::StopSpeech() {

--- a/SRC/NSSpeech.h
+++ b/SRC/NSSpeech.h
@@ -7,7 +7,7 @@ class NSSpeechSynthesizerWrapper;
 namespace Sral {
     class NsSpeech final : public Engine {
     public:
-			bool Initialize() override;
+        bool Initialize() override;
         bool Uninitialize() override;
         bool Speak(const char* text, bool interrupt) override;
         bool StopSpeech() override;
@@ -15,10 +15,16 @@ namespace Sral {
         bool GetActive() override;
         bool SetParameter(int param, const void* value) override;
         bool GetParameter(int param, void* value) override;
-        
-        int GetNumber() override { return SRAL_ENGINE_NS_SPEECH; }
-        int GetFeatures() override { 
-            return SRAL_SUPPORTS_SPEECH | SRAL_SUPPORTS_SPEECH_RATE | SRAL_SUPPORTS_SPEECH_VOLUME; 
+
+        int GetNumber() override {
+            return SRAL_ENGINE_NS_SPEECH;
+        }
+
+        int GetFeatures() override {
+            return SRAL_SUPPORTS_SPEECH |
+                SRAL_SUPPORTS_SPEECH_RATE |
+                SRAL_SUPPORTS_SPEECH_VOLUME |
+                SRAL_SUPPORTS_SELECT_VOICE;
         }
 
     private:

--- a/SRC/NSSpeech.mm
+++ b/SRC/NSSpeech.mm
@@ -1,16 +1,19 @@
 #include "NsSpeech.h"
+#include "Encoding.h"
 #import <AppKit/AppKit.h>
 
 class NSSpeechSynthesizerWrapper {
 public:
     NSSpeechSynthesizer* synth;
+    NSArray<NSVoiceIdentifier>* voices;
     float rate;
     float volume;
 
-    NSSpeechSynthesizerWrapper() : synth(nullptr), rate(175.0f), volume(1.0f) {}
+     NSSpeechSynthesizerWrapper() : synth(nullptr), voices(nil), rate(175.0f), volume(1.0f) {}
 
     bool Initialize() {
         synth = [[NSSpeechSynthesizer alloc] init];
+        voices = [[NSSpeechSynthesizer availableVoices] retain];
         if (synth) {
             rate = [synth rate];
             volume = [synth volume];
@@ -21,17 +24,27 @@ public:
     void Uninitialize() {
         if (synth) {
             [synth stopSpeaking];
+#if !__has_feature(objc_arc)
             [synth release];
+#endif
             synth = nil;
+        }
+        if (voices) {
+#if !__has_feature(objc_arc)
+            [voices release];
+#endif
+            voices = nil;
         }
     }
 
     bool Speak(const char* text, bool interrupt) {
-        if (!synth) return false;
-        if (interrupt) [synth stopSpeaking];
+       if (!synth || !text) return false;
+       if (interrupt) [synth stopSpeaking];
         
-        NSString* nsStr = [NSString stringWithUTF8String:text];
-        return [synth startSpeakingString:nsStr] == YES;
+       NSString* nsStr = [NSString stringWithUTF8String:text];
+       if (!nsStr) return false;
+
+       return [synth startSpeakingString:nsStr] == YES;
     }
 
     bool Stop() {
@@ -44,13 +57,25 @@ public:
     }
 
     void SetVolume(int val) {
-        this->volume = (float)val / 100.0f;
+        this->volume = fmaxf(0.0f, fminf(1.0f, (float)val / 100.0f));
         if (synth) [synth setVolume:this->volume];
     }
 
     void SetRate(int val) {
         this->rate = (float)val;
         if (synth) [synth setRate:this->rate];
+    }
+
+    bool SetVoice(int index) {
+        if (!synth || !voices || index < 0 || index >= (int)[voices count]) return false;
+        return [synth setVoice:[voices objectAtIndex:index]];
+    }
+
+    int GetCurrentVoiceIndex() {
+        if (!synth || !voices) return 0;
+        NSVoiceIdentifier current = [synth voice];
+        NSUInteger idx = [voices indexOfObject:current];
+        return (idx == NSNotFound) ? 0 : (int)idx;
     }
 };
 
@@ -87,24 +112,48 @@ bool NsSpeech::GetActive() {
 }
 
 bool NsSpeech::SetParameter(int param, const void* value) {
-    if (!obj) return false;
+    if (!obj || !value) return false;
     int val = *reinterpret_cast<const int*>(value);
     switch (param) {
         case SRAL_PARAM_SPEECH_RATE:   obj->SetRate(val); break;
         case SRAL_PARAM_SPEECH_VOLUME: obj->SetVolume(val); break;
+        case SRAL_PARAM_VOICE_INDEX:   return obj->SetVoice(val);
         default: return false;
     }
     return true;
 }
 
 bool NsSpeech::GetParameter(int param, void* value) {
-    if (!obj) return false;
+    if (!obj || !value) return false;
     switch (param) {
-        case SRAL_PARAM_SPEECH_RATE:   *(int*)value = (int)obj->rate; break;
-        case SRAL_PARAM_SPEECH_VOLUME: *(int*)value = (int)(obj->volume * 100); break;
+        case SRAL_PARAM_SPEECH_RATE:   
+            *(int*)value = (int)obj->rate; 
+            return true;
+        case SRAL_PARAM_SPEECH_VOLUME: 
+            *(int*)value = (int)(obj->volume * 100); 
+            return true;
+        case SRAL_PARAM_VOICE_INDEX:   
+            *(int*)value = obj->GetCurrentVoiceIndex(); 
+            return true;
+        case SRAL_PARAM_VOICE_COUNT:
+            *(int*)value = (int)[obj->voices count];
+            return true;
+        case SRAL_PARAM_VOICE_PROPERTIES: {
+            SRAL_VoiceInfo* info = static_cast<SRAL_VoiceInfo*>(value);
+            for (int i = 0; i < (int)[obj->voices count]; ++i) {
+                NSVoiceIdentifier vId = [obj->voices objectAtIndex:i];
+                NSDictionary* attr = [NSSpeechSynthesizer attributesForVoice:vId];
+                
+                info[i].index = i;
+                info[i].name = AddString([[attr objectForKey:NSVoiceName] UTF8String]);
+                info[i].language = AddString([[attr objectForKey:NSVoiceLocaleIdentifier] UTF8String]);
+                info[i].gender = AddString([[attr objectForKey:NSVoiceGender] UTF8String]);
+                info[i].vendor = AddString("Apple");
+            }
+            return true;
+        }
         default: return false;
     }
-    return true;
 }
 
 } // namespace Sral

--- a/SRC/NVDA.cpp
+++ b/SRC/NVDA.cpp
@@ -5,11 +5,16 @@
 
 namespace Sral {
 	bool Nvda::Initialize() {
-		int r = nvda_connect();
-		if (r == 0) {
+		if (nvda_connect() == 0) {
+			this->extended = true;
 			return true;
 		}
-		lib = LoadLibraryW(L"nvdaControllerClient.dll");
+
+		this->extended = false;
+		if (lib == nullptr) {
+			lib = LoadLibraryW(L"nvdaControllerClient.dll");
+		}
+
 		if (lib == nullptr) {
 			return false;
 		}
@@ -23,42 +28,47 @@ namespace Sral {
 
 	bool Nvda::Uninitialize() {
 		nvda_disconnect();
-		if (lib == nullptr)return true;
-		FreeLibrary(lib);
+		if (lib != nullptr) {
+			FreeLibrary(lib);
+			lib = nullptr;
+		}
 		nvdaController_speakText = nullptr;
 		nvdaController_brailleMessage = nullptr;
 		nvdaController_cancelSpeech = nullptr;
 		nvdaController_testIfRunning = nullptr;
 		nvdaController_speakSsml = nullptr;
+		this->extended = false;
 
 		return true;
 	}
 
 	bool Nvda::GetActive() {
 		if (nvda_active() == 0) {
+			if (!this->extended) Initialize();
 			this->extended = true;
 			return true;
 		}
-		else {
-			// Try to use the library
-			this->extended = false;
-			this->Uninitialize();
-			this->Initialize();
+
+		if (this->extended) {
+			Uninitialize();
+			Initialize();
 		}
 		if (lib == nullptr) return false;
-		if (nvdaController_testIfRunning) return  (!!FindWindowW(L"wxWindowClassNR", L"NVDA") && nvdaController_testIfRunning() == 0);
+		if (nvdaController_testIfRunning) {
+			return (!!FindWindowW(L"wxWindowClassNR", L"NVDA") && nvdaController_testIfRunning() == 0);
+		}
 		return false;
 	}
 
 	bool Nvda::Speak(const char* text, bool interrupt) {
 		if (!GetActive())return false;
 		if (interrupt) {
-			this->extended ? nvda_cancel_speech() : nvdaController_cancelSpeech();
+			this->extended ? nvda_cancel_speech() : (nvdaController_cancelSpeech ? nvdaController_cancelSpeech() : 0);
 		}
 		if (this->extended)
 			return !enable_spelling ? nvda_speak(text, this->symbolLevel) == 0 : nvda_speak_spelling(text, "", this->use_character_descriptions) == 0;
 		std::wstring out;
-		if (this->symbolLevel == -1) {
+		if (this->symbolLevel == -1 || !nvdaController_speakSsml) {
 			UnicodeConvert(text, out);
 			return nvdaController_speakText(out.c_str()) == 0;
 		}
@@ -71,25 +81,25 @@ namespace Sral {
 			UnicodeConvert(text, out);
 			return nvdaController_speakText(out.c_str()) == 0;
 		}
-		else {
-			return result == 0;
-		}
-		return false;
+		return result == 0;
 	}
 
 	bool Nvda::SpeakSsml(const char* ssml, bool interrupt) {
 		if (!GetActive())return false;
 		if (interrupt)
-			this->extended ? nvda_cancel_speech() : nvdaController_cancelSpeech();
+			this->extended ? nvda_cancel_speech() : (nvdaController_cancelSpeech ? nvdaController_cancelSpeech() : 0);
 		if (this->extended)
 			return nvda_speak_ssml(ssml, this->symbolLevel) == 0;
-		std::string text_str(ssml);
+
+		if (!nvdaController_speakSsml) return Speak(ssml, interrupt);
+
 		std::wstring out;
 		UnicodeConvert(ssml, out);
 		return nvdaController_speakSsml(out.c_str(), this->symbolLevel, 0, true) == 0;
 	}
 
 	bool Nvda::SetParameter(int param, const void* value) {
+		if (!value) return false;
 		switch (param) {
 		case SRAL_PARAM_SYMBOL_LEVEL:
 			this->symbolLevel = *reinterpret_cast<const int*>(value);
@@ -107,6 +117,7 @@ namespace Sral {
 	}
 
 	bool Nvda::GetParameter(int param, void* value) {
+		if (!value) return false;
 		switch (param) {
 		case SRAL_PARAM_SYMBOL_LEVEL:
 			*(int*)value = this->symbolLevel;
@@ -131,13 +142,14 @@ namespace Sral {
 		if (!GetActive())return false;
 		if (this->extended)
 			return nvda_braille(text) == 0;
+		if (!nvdaController_brailleMessage) return false;
 		std::wstring out;
 		UnicodeConvert(text, out);
 		return nvdaController_brailleMessage(out.c_str()) == 0;
 	}
 	bool Nvda::StopSpeech() {
 		if (!GetActive())return false;
-		return 		this->extended ? nvda_cancel_speech() == 0 : nvdaController_cancelSpeech() == 0;
+		return this->extended ? nvda_cancel_speech() == 0 : (nvdaController_cancelSpeech ? nvdaController_cancelSpeech() == 0 : false);
 	}
 	bool Nvda::PauseSpeech() {
 		if (!GetActive())return false;
@@ -158,6 +170,7 @@ namespace Sral {
 		return true;
 	}
 	bool Nvda::ResumeSpeech() {
-		return 		this->extended ? nvda_pause_speech(false) == 0 : PauseSpeech();
+		if (!GetActive()) return false;
+		return this->extended ? nvda_pause_speech(false) == 0 : PauseSpeech();
 	}
 }

--- a/SRC/Orca.cpp
+++ b/SRC/Orca.cpp
@@ -1,0 +1,63 @@
+#include "Orca.h"
+
+namespace Sral {
+
+    bool Orca::Initialize() {
+        DBusError err;
+        dbus_error_init(&err);
+        conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+
+        if (brlapi_openConnection(nullptr, nullptr) >= 0) {
+            if (brlapi_enterTtyMode(BRLAPI_TTY_DEFAULT, nullptr) >= 0) {
+                brailleInitialized = true;
+            }
+            else {
+                brlapi_closeConnection();
+            }
+        }
+
+        return (conn != nullptr);
+    }
+
+    bool Orca::Uninitialize() {
+        if (brailleInitialized) {
+            brlapi_leaveTtyMode();
+            brlapi_closeConnection();
+            brailleInitialized = false;
+        }
+        conn = nullptr;
+        return true;
+    }
+
+    bool Orca::Speak(const char* text, bool interrupt) {
+        if (!conn || !text) return false;
+
+        DBusMessage* msg = dbus_message_new_method_call(
+            "org.gnome.Orca", "/org/gnome/Orca", "org.gnome.Orca", "presentMessage");
+
+        if (!msg) return false;
+
+        dbus_message_append_args(msg, DBUS_TYPE_STRING, &text, DBUS_TYPE_INVALID);
+        dbus_connection_send(conn, msg, nullptr);
+        dbus_connection_flush(conn);
+        dbus_message_unref(msg);
+
+        return true;
+    }
+
+    bool Orca::Braille(const char* text) {
+        if (!brailleInitialized || !text) return false;
+        return brlapi_writeText(0, text) >= 0;
+    }
+
+    bool Orca::GetActive() {
+        if (!conn) return false;
+        return dbus_bus_name_has_owner(conn, "org.gnome.Orca", nullptr);
+    }
+
+    bool Orca::StopSpeech() {
+        Braille("");
+        return true;
+    }
+
+}

--- a/SRC/Orca.h
+++ b/SRC/Orca.h
@@ -1,0 +1,25 @@
+#ifndef ORCA_H_
+#define ORCA_H_
+#pragma once
+#include "Engine.h"
+#include <dbus/dbus.h>
+#include <brlapi.h>
+
+namespace Sral {
+    class Orca final : public Engine {
+    public:
+        bool Initialize() override;
+        bool Uninitialize() override;
+        bool Speak(const char* text, bool interrupt) override;
+        bool Braille(const char* text) override;
+        bool StopSpeech() override;
+        bool GetActive() override;
+        int GetNumber() override { return SRAL_ENGINE_ORCA; }
+        int GetFeatures() override { return SRAL_SUPPORTS_SPEECH | SRAL_SUPPORTS_BRAILLE; }
+
+    private:
+        DBusConnection* conn = nullptr;
+        bool brailleInitialized = false;
+    };
+}
+#endif

--- a/SRC/UIA.cpp
+++ b/SRC/UIA.cpp
@@ -30,16 +30,17 @@ namespace Sral {
 	}
 
 	bool Uia::Speak(const char* text, bool interrupt) {
-		NotificationProcessing flags = NotificationProcessing_ImportantAll;
-		if (interrupt)
-			flags = NotificationProcessing_ImportantMostRecent;
+
+		if (!UiaClientsAreListening()) return false;
+		NotificationProcessing flags = interrupt ? NotificationProcessing_ImportantMostRecent : NotificationProcessing_ImportantAll;
+
 		std::wstring str;
 		UnicodeConvert(text, str);
 		if (pProvider) {
-			pProvider->Release();
+			pProvider->Release(); pProvider = nullptr;
 		}
 		if (pElement) {
-			pElement->Release();
+			pElement->Release(); pElement = nullptr;
 		}
 		pProvider = new Provider(GetForegroundWindow());
 

--- a/SRC/VoiceOver.mm
+++ b/SRC/VoiceOver.mm
@@ -27,10 +27,13 @@ namespace Sral {
 #if TARGET_OS_IOS || TARGET_OS_TV
 		UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, msg);
 #elif TARGET_OS_OSX
-		NSDictionary* userInfo = @{ NSAccessibilityAnnouncementKey: msg };
-		NSAccessibilityPostNotificationWithUserInfo(NSApp, NSAccessibilityAnnouncementRequestedNotification, userInfo);
+	if (NSApp == nil) return false;
+
+	NSNumber* priority = interrupt ? @(NSAccessibilityPriorityHigh) : @(NSAccessibilityPriorityNormal);
+
+		NSDictionary* userInfo = @{ NSAccessibilityAnnouncementKey: msg, NSAccessibilityPriorityKey: priority };
+		NSAccessibilityPostNotificationWithUserInfo([NSApp mainWindow] ? [NSApp mainWindow] : NSApp, NSAccessibilityAnnouncementRequestedNotification, userInfo);
 #endif
-		(void)interrupt; // Unused yet
 		return true;
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -13,40 +13,80 @@ host_os = host_machine.system()
 
 inc_dir = include_directories('Include')
 
+# Options
 build_test = get_option('build_sral_test')
 disable_uia = get_option('sral_disable_uia')
+disable_nsspeech = get_option('sral_disable_nsspeech')
 
-sral_sources = [
+sral_sources = files(
   'SRC/Encoding.cpp',
   'SRC/SRAL.cpp',
   'SRC/Engine.cpp'
-]
+)
 
 sral_deps = []
-sral_args = ['-D_CRT_SECURE_NO_WARNINGS']
+sral_args = []
+
+# Targeted MSVC Warning Suppression
+if cpp.get_id() == 'msvc'
+  sral_args += '-D_CRT_SECURE_NO_WARNINGS'
+endif
 
 if host_os == 'windows'
-  sral_sources += [
+  sral_sources += files(
     'SRC/NVDA.cpp', 'SRC/SAPI.cpp',
     'Dep/blastspeak.c', 'Dep/fsapi.c', 'Dep/nvda_control.c',
     'SRC/Jaws.cpp', 'Dep/wasapi.cpp', 'SRC/ZDSR.cpp'
-  ]
+  )
+  
+  # Platform libs
+  sral_deps += cpp.find_library('ole32')
+  sral_deps += cpp.find_library('user32')
   
   if not disable_uia
-    sral_sources += ['SRC/UIA.cpp', 'Dep/UIAProvider.cpp']
+    sral_sources += files('SRC/UIA.cpp', 'Dep/UIAProvider.cpp')
     sral_deps += cpp.find_library('uiautomationcore')
   else
     sral_args += '-DSRAL_NO_UIA'
   endif
 
+  # AccessKit Check (Conditional)
+  ak_lib = cpp.find_library('accesskit', required : false)
+  if ak_lib.found()
+    sral_sources += files('SRC/ACAnnouncer.cpp')
+    sral_deps += ak_lib
+  else
+    sral_args += '-DSRAL_NO_ACCESSKIT'
+  endif
+
 elif host_os == 'darwin'
   add_languages('objcpp')
-  sral_sources += ['SRC/AVSpeech.mm', 'SRC/VoiceOver.mm', 'SRC/NSSpeech.mm']
+  sral_sources += files('SRC/AVSpeech.mm', 'SRC/VoiceOver.mm')
+  
+  if not disable_nsspeech
+    sral_sources += files('SRC/NSSpeech.mm')
+  else
+    sral_args += '-DSRAL_NO_NSSPEECH'
+  endif
+  
   sral_deps += dependency('appleframeworks', modules : ['AppKit', 'Foundation', 'AVFoundation'])
 
-else
-  sral_sources += ['Dep/utf-8.c', 'SRC/SpeechDispatcher.cpp']
+elif host_os == 'android'
+  sral_sources += files(
+    'SRC/AndroidTextToSpeech.cpp',
+    'SRC/AndroidAccessibilityManager.cpp',
+    'Dep/AndroidContext.cpp'
+  )
+  sral_deps += cpp.find_library('log')
+
+else # Linux / Generic
+  sral_sources += files(
+    'Dep/utf-8.c', 
+    'SRC/SpeechDispatcher.cpp', 
+    'SRC/Orca.cpp'
+  )
   sral_deps += dependency('speech-dispatcher')
+  sral_deps += dependency('dbus-1')
   sral_deps += cpp.find_library('brlapi')
 endif
 
@@ -61,12 +101,17 @@ sral_lib = library('SRAL',
 
 install_headers('Include/SRAL.h')
 
+# Internal dependency for easy linking in tests
+sral_dep = declare_dependency(
+  link_with : sral_lib,
+  include_directories : inc_dir,
+  compile_args : sral_args
+)
+
 if build_test
   executable('SRAL_test',
     'Examples/C/SRALExample.c',
-    include_directories : inc_dir,
-    link_with : sral_lib,
-    dependencies : sral_deps
+    dependencies : [sral_dep] + sral_deps
   )
 
   if host_os == 'windows'
@@ -80,6 +125,8 @@ endif
 summary({
   'Build tests': build_test,
   'UIA support disabled': disable_uia,
+  'NSSpeech disabled': disable_nsspeech,
   'Library type': get_option('default_library'),
-  'C++ Standard': get_option('cpp_std')
+  'C++ Standard': get_option('cpp_std'),
+  'AccessKit found': ak_lib.found()
 }, bool_yn: true, section: 'Configuration')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,29 @@
-option('build_sral_test', type : 'boolean', value : true, description : 'Build SRAL examples/tests')
-option('sral_disable_uia', type : 'boolean', value : false, description : 'Disable UIA (UI Automation) support')
+option('build_sral_test', 
+  type : 'boolean', 
+  value : true, 
+  description : 'Build SRAL examples/tests'
+)
+
+option('sral_disable_uia', 
+  type : 'boolean', 
+  value : false, 
+  description : 'Disable UIA (UI Automation) support'
+)
+
+option('sral_disable_nsspeech', 
+  type : 'boolean', 
+  value : false, 
+  description : 'Disable NSSpeech (macOS-only NSSpeechSynthesizer) support'
+)
+
+option('sral_disable_orca', 
+  type : 'boolean', 
+  value : false, 
+  description : 'Disable Orca (D-Bus) support on Linux'
+)
+
+option('sral_accesskit_path',
+  type : 'string',
+  value : '',
+  description : 'Custom path to search for the AccessKit C-binding library'
+)


### PR DESCRIPTION
- Revamped CMakeLists: centralized includes, MSVC runtime/hotreload handling, feature options, platform-specific source selection, improved linking/install rules, and additional CMake presets (macOS, Android, cross). UIA and NSSpeech can be toggled; AccessKit is detected and integrated when present.
- Updated CMakePresets.json: new base presets, platform-specific presets, and consistent cache variable formatting.
- Meson build updates: mirror the CMake changes (new options, AccessKit detection, Orca on Linux), refined test dependency handling and summary output.
- Added Orca.h / Orca.cpp: new Linux Orca engine using D-Bus and BRLAPI for speech and braille.
- ACAnnouncer: implement adapter lifecycle, live region status, safer update calls.
- AVSpeech / NSSpeech: robust initialization/uninitialization, voice selection, rate/volume mapping, parameter handling, ARC-aware memory management, and expanded voice metadata support.
- NVDA, Jaws, UIA, VoiceOver: multiple bug fixes and safety checks (resource release, null checks, safer DLL/API usage, proper notification priority handling).
- README: updated requirements and added platform/language support notes.
- meson_options: new options for NSSpeech, Orca and AccessKit path.
- Bindings: Added C# (.net) and Lua bindings